### PR TITLE
move the benchmark out of the main library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ os:
   - windows
 
 rust:
+  - stable
   - nightly
 
 script:
   - cargo build
   - cargo doc
-  - cargo bench
+  - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
+      cargo bench;
+    fi

--- a/benches/test.rs
+++ b/benches/test.rs
@@ -1,12 +1,14 @@
 //! Module containing benchmarks
 #![allow(unused_imports)]
 
-extern crate test;
+#![feature(test)]
+extern crate tweet;
 
 #[cfg(test)]
+extern crate test;
 
 use test::test::Bencher;
-use parse::parse_tweets;
+use tweet::parse::parse_tweets;
 use std::io::prelude::*;
 use std::fs::File;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! ```c
 //! tw help
 //! ```
-#![feature(test)]
 #[macro_use] 
 
 extern crate nom;
@@ -25,7 +24,6 @@ use types::Tweet;
 
 pub mod parse;
 pub mod types;
-pub mod test;
 
 /// Reads credentials from a string, i.e. gets them from a file.
 ///


### PR DESCRIPTION
By moving the benchmark out of the main library and implementing it as a
standalone benchmark, it is possible to compile tw-rs with the stable
compiler and still retain the ability to run benchmarks.